### PR TITLE
Use StableRNGs.jl during test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 
 [targets]
-test = ["Test"]
+test = ["Test", "StableRNGs"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,17 @@
 using Ising2D
-using Random: seed!
+using StableRNGs: StableRNG
 using Test
 
 @testset "Ising2D.jl" begin
     N = 100
 
-    seed!(4649373)
-    S_ifelse = [ising2d!(IfElse(), rand_ising2d(), β_ising2d, 100) for _ in 1:N]
+    rng = StableRNG(123)
+    S_ifelse = [ising2d!(IfElse(), rand_ising2d(rng), β_ising2d, 100, rng) for _ in 1:N]
     @test abs(sum(energy_density_ising2d.(S_ifelse))/N + 1.37) < 0.015
     @test abs(sum(abs.(magnetization_ising2d.(S_ifelse)))/N - 0.184) < 0.07
 
-    seed!(4649373)
-    S_multifor = [ising2d!(MultiFor(), rand_ising2d(), β_ising2d, 100) for _ in 1:N]
+    rng = StableRNG(123)
+    S_multifor = [ising2d!(MultiFor(), rand_ising2d(rng), β_ising2d, 100, rng) for _ in 1:N]
     @test abs(sum(energy_density_ising2d.(S_multifor))/N + 1.37) < 0.015
     @test abs(sum(abs.(magnetization_ising2d.(S_multifor)))/N - 0.184) < 0.07
 


### PR DESCRIPTION
[The Julia documentation](https://docs.julialang.org/en/v1/stdlib/Random/#Reproducibility) advises us to use [StableRNGs.jl](https://github.com/JuliaRandom/StableRNGs.jl).


> This package intends to provide a simple RNG with stable streams, suitable for tests in packages which need reproducible streams of random numbers across Julia versions.